### PR TITLE
Fix content loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -477,6 +477,10 @@ endif
 CFLAGS   += -Wall $(INCFLAGS) $(INCFLAGS_PLATFORM)
 CXXFLAGS += -Wall $(INCFLAGS) $(INCFLAGS_PLATFORM)
 
+ifeq ($(DEBUG),1)
+CFLAGS += -O0 -g
+endif
+
 ifneq (,$(findstring msvc,$(platform)))
 ifeq ($(DEBUG),1)
 CFLAGS += -MTd

--- a/src/fileformat.c
+++ b/src/fileformat.c
@@ -187,9 +187,11 @@ bool get_file_data(const char *path,file_data ***dest_files, int *dest_numfiles)
     else
     {
         file_data *fd;
+        fp = fopen(path,"rb");
+        if (!fp)
+            return false;
         files = malloc(sizeof(file_data*));
         fd = malloc(sizeof(file_data));
-        fp = fopen(path,"rb");
         //get file length
         fseek (fp,0,SEEK_END);
         fd->length = ftell(fp);

--- a/src/libretro.c
+++ b/src/libretro.c
@@ -10,7 +10,7 @@
 #include "log.h"
 
 // Static globals
-static surface *framebuffer = NULL;;
+static surface *framebuffer = NULL;
 static uint16_t previnput = 0;
 
 // Callbacks
@@ -87,7 +87,7 @@ void retro_get_system_info(struct retro_system_info *info)
    memset(info, 0, sizeof(*info));
    info->library_name = "Game Music Emulator";
    info->library_version = "v0.6.1";
-   info->need_fullpath = false;
+   info->need_fullpath = true;
    info->valid_extensions = "ay|gbs|gym|hes|kss|nsf|nsfe|sap|spc|vgm|vgz|zip";
    info->block_extract = true;
 }
@@ -123,7 +123,9 @@ void retro_init(void)
 // End of retrolib
 void retro_deinit(void)
 {
-   free(framebuffer);
+   if (framebuffer)
+      free_surface(framebuffer);
+   framebuffer = NULL;
 }
 
 // Reset gme
@@ -171,8 +173,7 @@ bool retro_load_game(const struct retro_game_info *info)
 {
    long sample_rate = 44100;
 
-   // ensure there is ROM data
-   if (!info || !info->data)
+   if (!info)
       return false;
 
    if(open_file(info->path,sample_rate))

--- a/src/player.c
+++ b/src/player.c
@@ -37,7 +37,8 @@ bool open_file(const char *path, long sample_rate)
 
 void close_file(void)
 {
-	gme_delete( emu );
+	gme_delete(emu);
+	emu = NULL;
 	if(plist!=NULL)
 		cleanup_playlist(plist);
 }


### PR DESCRIPTION
At present it is impossible to load content with the core. This is because:

1) The core incorrectly sets `need_fullpath = false`, when it absolutely does need the full content path
2) Regardless of whether a valid content path is given, It fails to load content if the frontend passes a content data buffer - which will always be the case, since `need_fullpath = false`....

This trivial PR fixes this content load issue. It also:

- Prevents a segfault when an invalid content path is provided
- Prevents a segfault when loading content successively
- Fixes a few of the more obvious memory leaks (there are a great many of these...)

It should be noted that this core is in a rather sorry state, and needs a large amount of polishing. But at least it can now load content....