### PR TITLE
Add reset support and remove audio stuttering

### DIFF
--- a/src/libretro.c
+++ b/src/libretro.c
@@ -146,7 +146,7 @@ void retro_deinit(void)
 // Reset gme
 void retro_reset(void)
 {
-
+    start_track(0);
 }
 
 // Run a single frame
@@ -180,7 +180,7 @@ void retro_run(void)
    draw_ui();
    video_cb(framebuffer->pixel_data, framebuffer->width, framebuffer->height, framebuffer->bytes_per_pixel * framebuffer->width);
    //audio handling
-   audio_batch_cb(play(),1470);
+   audio_batch_cb(play(),735);
 }
 
 // File Loading

--- a/src/player.c
+++ b/src/player.c
@@ -86,7 +86,7 @@ short *play(void)
             is_playing_ = false;
       }
       else
-         gme_play( emu, 2048, audio_buffer );
+         gme_play( emu, 1470, audio_buffer );
    }
    else
       memset(audio_buffer,0,8192 * sizeof(short));


### PR DESCRIPTION
After upgrading from Lakka 3.6 to 3.7, framerate is cut in half because too much audio is queued on each frame.