### PR TITLE
fix build on webOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,11 @@ else
 
 endif
 
+# webOS
+ifneq (,$(or $(findstring webos,$(CROSS_COMPILE)),$(findstring starfish,$(CROSS_COMPILE))))
+	CFLAGS += -D_GNU_SOURCE
+endif
+
 include Makefile.common
 
 ifeq (,$(findstring msvc,$(platform)))


### PR DESCRIPTION
Currently fails to build with:

```
deps/libretro-common/encodings/encoding_utf.c: In function ‘utf8_to_local_string_alloc’:
deps/libretro-common/encodings/encoding_utf.c:359:14: error: implicit declaration of function ‘strdup’; did you mean ‘strldup’? [-Wimplicit-function-declaration]
  359 |       return strdup(str);
      |              ^~~~~~
      |              strldup
deps/libretro-common/encodings/encoding_utf.c:359:14: error: returning ‘int’ from a function with return type ‘char *’ makes pointer from integer without a cast [-Wint-conversion]
  359 |       return strdup(str);
```